### PR TITLE
Remove extraneous backtick causing types to not get detected.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,22 +12,22 @@
     ".": {
       "default": "./dist-min/aberdeen.js",
       "development": "./dist/aberdeen.js",
-      "types`": "./dist/aberdeen.d.ts"
+      "types": "./dist/aberdeen.d.ts"
     },
     "./route": {
       "default": "./dist-min/route.js",
       "development": "./dist/route.js",
-      "types`": "./dist/route.d.ts"
+      "types": "./dist/route.d.ts"
     },
     "./transition": {
       "default": "./dist-min/transition.js",
       "development": "./dist/transition.js",
-      "types`": "./dist/transition.d.ts"
+      "types": "./dist/transition.d.ts"
     },
     "./prediction": {
       "default": "./dist-min/prediction.js",
       "development": "./dist/prediction.js",
-      "types`": "./dist/prediction.d.ts"
+      "types": "./dist/prediction.d.ts"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
Hello. Thanks for creating aberdeen. Love the API. 

I am trying to use it in a new project and realized that types were not getting detected. There is a trailing backtick in the types field - removing that fixes this problem.